### PR TITLE
Implement invite notifications

### DIFF
--- a/src/services/wifi-portal-service.ts
+++ b/src/services/wifi-portal-service.ts
@@ -2,8 +2,9 @@
 import { 
   WifiUser, 
   WifiSession, 
-  PortalStatistic, 
+  PortalStatistic,
   SMSMessage,
+  EmailMessage,
   FamilyProfile,
   FamilyMember,
   FamilyInvite,
@@ -13,14 +14,16 @@ import { userService } from "./wifi/user-service";
 import { sessionService } from "./wifi/session-service";
 import { statisticsService } from "./wifi/statistics-service";
 import { smsService } from "./wifi/sms-service";
+import { emailService } from "./wifi/email-service";
 import { familyService } from "./wifi/family";
 
 // Re-export all types and services
-export type { 
-  WifiUser, 
-  WifiSession, 
-  PortalStatistic, 
+export type {
+  WifiUser,
+  WifiSession,
+  PortalStatistic,
   SMSMessage,
+  EmailMessage,
   FamilyProfile,
   FamilyMember,
   FamilyInvite,
@@ -44,6 +47,7 @@ export const wifiPortalService = {
   
   // SMS services
   sendSMS: smsService.sendSMS,
+  sendEmail: emailService.sendEmail,
   generateVerificationCode: smsService.generateVerificationCode,
   sendVerificationCode: smsService.sendVerificationCode,
   verifyCode: smsService.verifyCode,

--- a/src/services/wifi/email-service.ts
+++ b/src/services/wifi/email-service.ts
@@ -1,0 +1,19 @@
+import { EmailMessage } from './types';
+
+export const emailService = {
+  async sendEmail(emailData: EmailMessage): Promise<boolean> {
+    try {
+      console.log(`Sending email to ${emailData.to}: ${emailData.subject}`);
+      const success = Math.random() > 0.1; // simulate 90% success
+      if (!success) {
+        console.error(`Failed to send email to ${emailData.to}`);
+        return false;
+      }
+      // In a real implementation, integrate with an email provider here
+      return true;
+    } catch (error) {
+      console.error('Failed to send email:', error);
+      return false;
+    }
+  }
+};

--- a/src/services/wifi/family/family-invite-service.ts
+++ b/src/services/wifi/family/family-invite-service.ts
@@ -2,9 +2,36 @@
 import { supabase } from "@/integrations/supabase/client";
 import { FamilyInvite } from "../types";
 import { FamilyRole } from "@/components/wifi-portal/types";
+import { smsService } from "../sms-service";
+import { emailService } from "../email-service";
 
 // Mock data for development
 const mockFamilyInvites: FamilyInvite[] = [];
+
+const sendInviteNotification = async (invite: FamilyInvite): Promise<boolean> => {
+  const link = `https://example.com/invite/${invite.token}`;
+  try {
+    if (invite.email) {
+      return await emailService.sendEmail({
+        to: invite.email,
+        subject: "Invitation à rejoindre une famille",
+        body: `Vous avez été invité à rejoindre une famille. Cliquez ici pour accepter: ${link}`,
+        type: 'invite'
+      });
+    } else if (invite.phone) {
+      return await smsService.sendSMS({
+        to: invite.phone,
+        message: `Invitation à rejoindre la famille: ${link}`,
+        type: 'notification'
+      });
+    }
+    console.error('No contact info available to send invite');
+    return false;
+  } catch (err) {
+    console.error('Failed to send invite notification:', err);
+    return false;
+  }
+};
 
 /**
  * Service for managing family invites
@@ -49,12 +76,15 @@ export const familyInviteService = {
       //   .single();
       // if (error) throw error;
       
+      const notificationSent = await sendInviteNotification(newInvite);
+      if (!notificationSent) {
+        console.error('Failed to notify invitee');
+        return null;
+      }
+
       // For development:
       mockFamilyInvites.push(newInvite);
-      
-      // TODO: Send an email or SMS with the invitation link
-      // containing the token
-      
+
       return newInvite;
     } catch (error) {
       console.error(`Failed to create family invite:`, error);

--- a/src/services/wifi/types.ts
+++ b/src/services/wifi/types.ts
@@ -41,6 +41,14 @@ export interface SMSVerification {
   attempts: number;
 }
 
+export interface EmailMessage {
+  to: string;
+  subject: string;
+  body: string;
+  type?: 'invite' | 'notification';
+  status?: 'pending' | 'sent' | 'delivered' | 'failed';
+}
+
 // Nouvelles interfaces pour la gestion de famille
 export interface FamilyProfile {
   id: string;


### PR DESCRIPTION
## Summary
- add EmailMessage interface and email service helper
- implement notification sending when creating a family invite
- export new email service via wifi-portal-service

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869ea86a6648320896a1e26d343ecc1